### PR TITLE
show page posts in followers' home feed

### DIFF
--- a/controllers/getIndividualUser.js
+++ b/controllers/getIndividualUser.js
@@ -27,6 +27,7 @@ const { sendPushNotification } = require('../config/pushNotification');
 const FeedReports = require('../models/FeedReports');
 const Block = require('../models/Block');
 const Category = require('../models/Category');
+const PageFollower = require('../models/PageFollower');
 const ChallengePayment = require('../models/ChallengePayment');
 const Message = require('../models/Message');
 const MessageRequest = require('../models/MessageRequest');
@@ -2482,6 +2483,13 @@ exports.getAllHashTag = async (req, res) => {
     const followingIds = followings.map(f => f.followingId);
     const idsArray = [loggedInUserId, ...followingIds];
 
+    // === Get followed pages ===
+    const followedPageRows = await PageFollower.findAll({
+      where: { user_id: loggedInUserId },
+      attributes: ['page_id'],
+    });
+    const followedPageIds = followedPageRows.map(p => p.page_id);
+
     // === Get friends ===
     const friends = await FriendRequest.findAll({
       where: {
@@ -2527,6 +2535,9 @@ exports.getAllHashTag = async (req, res) => {
     if (friendIdArray.length > 0) {
       visibilityConditions.push(`(f."postType" = 'onlyme' AND f."userId" IN (:friendIds))`);
     }
+    if (followedPageIds.length > 0) {
+      visibilityConditions.push(`(f."activityType" = 'page_post' AND f."pageId" IN (:followedPageIds))`);
+    }
 
     // === Exclude blocked users ===
     const excludeCondition = excludedUserIds.length
@@ -2539,6 +2550,7 @@ exports.getAllHashTag = async (req, res) => {
         f."id", f."userId", f."activityType", f."images", f."title", f."randomCode", f."awards", f."description", f."gymId", f."mentions", f."link",
         f."imageUrl", f."like_count", f."comment_count", f."report_count",
         f."postType", f."mentionedUserIds", f."price", f."myBookmarks", f."timestamp", f."createdAt", f."updatedAt",
+        f."pageId",
         u.full_name AS "user.full_name",
         u.profile_pic AS "user.profile_pic",
         g.id AS "gym.id",
@@ -2566,6 +2578,7 @@ exports.getAllHashTag = async (req, res) => {
       ids: idsArray,
       friendIds: friendIdArray,
       ...(excludedUserIds.length && { excludedUserIds }),
+      ...(followedPageIds.length && { followedPageIds }),
     };
 
     // === Extra filters ===

--- a/controllers/pagesController.js
+++ b/controllers/pagesController.js
@@ -7,6 +7,7 @@ const Page         = require('../models/Page');
 const PageFollower = require('../models/PageFollower');
 const PagePost     = require('../models/PagePost');
 const User         = require('../models/User');
+const Feed         = require('../models/Feed');
 const PushNotification = require('../models/PushNotification');
 
 const CLOUDFRONT = process.env.CLOUDFRONT_URL;
@@ -414,6 +415,18 @@ exports.createPost = async (req, res) => {
     }
 
     await page.increment('post_count');
+
+    // Create a single Feed entry — home feed query will fan it out to followers
+    await Feed.create({
+      userId:       userId,
+      activityType: 'page_post',
+      title:        page.name,
+      description:  post.content  || null,
+      imageUrl:     post.image_url || null,
+      pageId:       page.id,
+      postType:     'public',
+      timestamp:    new Date(),
+    });
 
     // Fire-and-forget push notifications to all followers
     notifyFollowers(page, post).catch(err => console.error('notifyFollowers error:', err));

--- a/migrations/20260710000000-add-page-post-to-feed-activitytype.js
+++ b/migrations/20260710000000-add-page-post-to-feed-activitytype.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query(`
+      ALTER TYPE "enum_Feeds_activityType" ADD VALUE IF NOT EXISTS 'page_post';
+    `);
+  },
+  down: async () => {
+    // PostgreSQL does not support removing ENUM values
+  },
+};

--- a/models/Feed.js
+++ b/models/Feed.js
@@ -17,8 +17,13 @@ const Feed = sequelize.define('Feed', {
     }
   },
   activityType: {
-    type: DataTypes.ENUM('checkin', 'workoutInvite', 'milestone', 'questionPrompt', 'gymAd', 'aiPromo', 'general', 'then_now', 'meal', "challenge"),
+    type: DataTypes.ENUM('checkin', 'workoutInvite', 'milestone', 'questionPrompt', 'gymAd', 'aiPromo', 'general', 'then_now', 'meal', 'challenge', 'page_post'),
     allowNull: false
+  },
+  pageId: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    defaultValue: null,
   },
   price: {
     type: DataTypes.INTEGER,


### PR DESCRIPTION
- add page_post activityType to Feed ENUM + pageId column
- create one Feed entry per page post (public, pageId set)
- home feed query includes page posts from pages user follows
- migration: ALTER TYPE enum_Feeds_activityType ADD VALUE page_post